### PR TITLE
Support Gzip-ed content to be stringified

### DIFF
--- a/src/main/scala/bubblewrap/PageParser.scala
+++ b/src/main/scala/bubblewrap/PageParser.scala
@@ -8,16 +8,15 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 
 import scala.collection.JavaConversions._
+import scala.util.Try
 
 case class Content(url: WebUrl, content: Array[Byte], contentType: Option[String] = None, contentCharset: Option[String] = None, contentEncoding: Option[String] = None) extends ContentType {
   def asString = {
     if (isGzip(this)) {
-      try {
+      Try({
         val gzipStream = new GZIPInputStream(new ByteArrayInputStream(content))
         scala.io.Source.fromInputStream(gzipStream).mkString
-      } catch {
-        case e: Exception => new String(content, contentCharset.getOrElse("UTF-8"))
-      }
+      }).getOrElse(new String(content, contentCharset.getOrElse("UTF-8")))
     } else {
       new String(content, contentCharset.getOrElse("UTF-8"))
     }

--- a/src/main/scala/bubblewrap/PageParser.scala
+++ b/src/main/scala/bubblewrap/PageParser.scala
@@ -12,8 +12,12 @@ import scala.collection.JavaConversions._
 case class Content(url: WebUrl, content: Array[Byte], contentType: Option[String] = None, contentCharset: Option[String] = None, contentEncoding: Option[String] = None) extends ContentType {
   def asString = {
     if (isGzip(this)) {
-      val gzipStream = new GZIPInputStream(new ByteArrayInputStream(content))
-      scala.io.Source.fromInputStream(gzipStream).mkString
+      try {
+        val gzipStream = new GZIPInputStream(new ByteArrayInputStream(content))
+        scala.io.Source.fromInputStream(gzipStream).mkString
+      } catch {
+        case e: Exception => new String(content, contentCharset.getOrElse("UTF-8"))
+      }
     } else {
       new String(content, contentCharset.getOrElse("UTF-8"))
     }

--- a/src/main/scala/bubblewrap/PageParser.scala
+++ b/src/main/scala/bubblewrap/PageParser.scala
@@ -1,25 +1,63 @@
 package bubblewrap
 
+import java.io.ByteArrayInputStream
 import java.util.regex.Pattern
+import java.util.zip.GZIPInputStream
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 
 import scala.collection.JavaConversions._
 
-case class Content(url: WebUrl, content: Array[Byte], contentType: Option[String] = None, contentCharset: Option[String] = None,  contentEncoding: Option[String] = None) {
-  def asString = new String(content,contentCharset.getOrElse("UTF-8"))
+case class Content(url: WebUrl, content: Array[Byte], contentType: Option[String] = None, contentCharset: Option[String] = None, contentEncoding: Option[String] = None) extends ContentType {
+  def asString = {
+    if (isGzip(this)) {
+      val gzipStream = new GZIPInputStream(new ByteArrayInputStream(content))
+      scala.io.Source.fromInputStream(gzipStream).mkString
+    } else {
+      new String(content, contentCharset.getOrElse("UTF-8"))
+    }
+  }
+
   def asBytes = content
+
   def length = content.length
+
   def contentLength = asString.length
 }
-class Page(val content:Content) {
-  def metaRefresh:Option[WebUrl] = None
-  def canonicalUrl:Option[WebUrl] = None
-  def outgoingLinks:List[WebUrl] = List.empty
+
+trait ContentType {
+  val gzipVariants = List(
+    "application/gzip",
+    "application/x-gzip",
+    "application/x-gunzip",
+    "application/gzipped",
+    "application/gzip-compressed",
+    "gzip/document"
+  )
+
+  def isGzip(content: Content) = {
+    (content.contentEncoding, content.contentType) match {
+      case (Some(encoding), _) => gzipVariants.exists(gz => gz.equals(encoding))
+      case (None, Some(cType)) => gzipVariants.exists(gz => gz.equals(cType))
+      case (_, _) => false
+    }
+  }
+}
+
+class Page(val content: Content) {
+  def metaRefresh: Option[WebUrl] = None
+
+  def canonicalUrl: Option[WebUrl] = None
+
+  def outgoingLinks: List[WebUrl] = List.empty
+
   def url = content.url
+
   def contentType = content.contentType
+
   def contentCharset = content.contentCharset
+
   def contentEncoding = content.contentEncoding
 }
 
@@ -36,28 +74,33 @@ object Page {
       lazy val metaRefreshB = metaRefreshRef
       lazy val canonicalUrlB = canonicalUrlRef
       lazy val outgoingLinksB = outgoingLinksRef
+
       override def metaRefresh = metaRefreshB
+
       override def canonicalUrl = canonicalUrlB
+
       override def outgoingLinks = outgoingLinksB
     }
   }
 }
 
-object Content{
+object Content {
   def apply(url: WebUrl, body: Array[Byte], responseHeaders: ResponseHeaders): Content = {
-    Content(url, body,responseHeaders.contentEncoding, responseHeaders.contentCharset, responseHeaders.contentType)
+    Content(url, body, responseHeaders.contentEncoding, responseHeaders.contentCharset, responseHeaders.contentType)
   }
 }
 
 
 class PageParser {
+
   import PageParser._
+
   def parse(content: Content): Page = {
     val doc = Jsoup.parse(content.asString)
     Page(content, metaRefresh(content.url, doc), canonicalUrl(content.url, doc), outgoingLinks = outgoingLinks(content.url, doc))
   }
 
-  private def metaRefresh(baseUrl:WebUrl,doc: Document) = {
+  private def metaRefresh(baseUrl: WebUrl, doc: Document) = {
     doc.getElementsByAttributeValueMatching("http-equiv", Pattern.compile("refresh", Pattern.CASE_INSENSITIVE))
       .headOption
       .map(element => element.attr("content"))
@@ -66,16 +109,16 @@ class PageParser {
       }
   }
 
-  private def canonicalUrl(baseUrl:WebUrl, doc: Document) = {
+  private def canonicalUrl(baseUrl: WebUrl, doc: Document) = {
     doc.getElementsByAttributeValue("rel", "canonical")
       .headOption
       .map(element => baseUrl.resolve(element.attr("href")))
   }
 
-  private def outgoingLinks(baseUrl:WebUrl, doc: Document): List[WebUrl] = {
-    if(noFollow(doc)) return List.empty
+  private def outgoingLinks(baseUrl: WebUrl, doc: Document): List[WebUrl] = {
+    if (noFollow(doc)) return List.empty
     (doc.getElementsByTag("a") ++ doc.getElementsByTag("link"))
-      .flatMap{ element => extractLink(baseUrl, element) }
+      .flatMap { element => extractLink(baseUrl, element) }
       .toList
   }
 
@@ -85,17 +128,17 @@ class PageParser {
       .exists(element => element.attr("content").matches(NOFOLLOW))
   }
 
-  private def extractLink(baseUrl:WebUrl, elem: Element) = {
+  private def extractLink(baseUrl: WebUrl, elem: Element) = {
     val href = elem.attr("href").trim
     val shouldFollow = elem.attr("rel") != "nofollow"
     val isCanonical = elem.attr("rel") == "canonical"
     val isWebPageLink = allowedSchemes(href) && notHasIllegalCharacters(href)
-    if(isWebPageLink && shouldFollow && !isCanonical) Some(baseUrl.resolve(href)) else None
+    if (isWebPageLink && shouldFollow && !isCanonical) Some(baseUrl.resolve(href)) else None
   }
 
-  private def notHasIllegalCharacters(href:String) = !href.contains("@")
+  private def notHasIllegalCharacters(href: String) = !href.contains("@")
 
-  private def allowedSchemes(href:String) = href match {
+  private def allowedSchemes(href: String) = href match {
     case SCHEME(scheme) => schemes contains scheme.trim.toLowerCase
     case _ => true
   }
@@ -105,6 +148,7 @@ object PageParser {
   val MetaUrl = "(?i)[^;]*;\\s*URL\\s*=(.*)".r
   val NOFOLLOW = "(?i).*nofollow.*"
   val SCHEME = "(?s)([^:]+):.*".r
-  val schemes = Set("http","https")
+  val schemes = Set("http", "https")
+
   def apply() = new PageParser()
 }

--- a/src/test/scala/bubblewrap/HttpClientIntegrationSpec.scala
+++ b/src/test/scala/bubblewrap/HttpClientIntegrationSpec.scala
@@ -20,4 +20,17 @@ class HttpClientIntegrationSpec extends FlatSpec {
 
     Await.result(body, 100000 millis)
   }
+
+  it should "fetch some Gzip-ed page" in {
+    val url = "https://www.grainger.com/product-items-sitemap28.xml.gz"
+    val client: HttpClient = new HttpClient()
+    val body = client.get(WebUrl.from(url), CrawlConfig(None, "" , 100000000, 10, Cookies.None)).map { response =>
+      response.pageResponse match {
+        case SuccessResponse(page) => page.asString
+        case FailureResponse(error) => error.printStackTrace(); List.empty[WebUrl]
+      }
+    }
+
+    println(Await.result(body, 100000 millis))
+  }
 }

--- a/src/test/scala/bubblewrap/HttpClientIntegrationSpec.scala
+++ b/src/test/scala/bubblewrap/HttpClientIntegrationSpec.scala
@@ -22,7 +22,7 @@ class HttpClientIntegrationSpec extends FlatSpec {
   }
 
   it should "fetch some Gzip-ed page" in {
-    val url = "https://www.grainger.com/product-items-sitemap28.xml.gz"
+    val url = "https://en.wikipedia.org/wiki/Daft_Punk"
     val client: HttpClient = new HttpClient()
     val body = client.get(WebUrl.from(url), CrawlConfig(None, "" , 100000000, 10, Cookies.None)).map { response =>
       response.pageResponse match {

--- a/src/test/scala/bubblewrap/HttpClientIntegrationSpec.scala
+++ b/src/test/scala/bubblewrap/HttpClientIntegrationSpec.scala
@@ -22,7 +22,7 @@ class HttpClientIntegrationSpec extends FlatSpec {
   }
 
   it should "fetch some Gzip-ed page" in {
-    val url = "https://en.wikipedia.org/wiki/Daft_Punk"
+    val url = "https://www.yahoo.com/style/sitemaps/sitemap_index_us_en-US.xml.gz"
     val client: HttpClient = new HttpClient()
     val body = client.get(WebUrl.from(url), CrawlConfig(None, "" , 100000000, 10, Cookies.None)).map { response =>
       response.pageResponse match {
@@ -30,7 +30,6 @@ class HttpClientIntegrationSpec extends FlatSpec {
         case FailureResponse(error) => error.printStackTrace(); List.empty[WebUrl]
       }
     }
-
-    println(Await.result(body, 100000 millis))
+    Await.result(body, 100000 millis)
   }
 }


### PR DESCRIPTION
This PR allows bubblewrap to return decompressed response content.

Example URL —

```
https://www.example.com/sitemap.xml.gz
```

```bash
$ curl -i "https://www.example.com/sitemap.xml.gz"

HTTP/2 200
accept-ranges: bytes
content-length: 478717
content-type: application/x-gzip

Warning: Binary output can mess up your terminal. Use "--output -" to tell
Warning: curl to output it to your terminal anyway, or consider "--output
Warning: <FILE>" to save to a file.
```

🙏🏻 @brewkode for helping write this!