### PR TITLE
Upgrade to AHC 2.5.3.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val asyncHttpClient = "org.asynchttpclient" % "async-http-client" % "2.0.29"
+val asyncHttpClient = "org.asynchttpclient" % "async-http-client" % "2.5.3"
 val commonsIo = "commons-io" % "commons-io" % "2.4"
 val jsoup = "org.jsoup" % "jsoup" % "1.8.1"
 val tika = "org.apache.tika" % "tika-core" % "1.4"

--- a/src/main/scala/bubblewrap/HttpClient.scala
+++ b/src/main/scala/bubblewrap/HttpClient.scala
@@ -9,11 +9,9 @@ import io.netty.handler.codec.http.cookie.ClientCookieDecoder
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory
 import io.netty.handler.ssl.{SslContextBuilder, SslProvider}
 import io.netty.util.HashedWheelTimer
-import org.asynchttpclient.cookie.ThreadSafeCookieStore
 import org.asynchttpclient.netty.NettyResponseFuture
 import org.asynchttpclient.netty.channel.DefaultChannelPool
 import org.asynchttpclient.proxy.ProxyServer
-import org.asynchttpclient.uri.Uri
 import org.asynchttpclient.{DefaultAsyncHttpClient, DefaultAsyncHttpClientConfig, Realm}
 
 import scala.collection.JavaConverters._
@@ -78,8 +76,6 @@ object HttpClient {
   val oneYear = 360l * 24 * 60 * 60 * 1000
 
   def cookies(config: CrawlConfig, url: String) = {
-    val cookieStore = new ThreadSafeCookieStore()
-
     config.cookies.cookies
       .map(cookie => {
         val _cookie = ClientCookieDecoder.LAX.decode(s"${cookie._1}=${cookie._2}")

--- a/src/main/scala/bubblewrap/HttpHandler.scala
+++ b/src/main/scala/bubblewrap/HttpHandler.scala
@@ -6,7 +6,8 @@ import java.util.concurrent.TimeoutException
 
 import io.netty.handler.codec.http.DefaultHttpHeaders
 import org.asynchttpclient.AsyncHandler.State
-import org.asynchttpclient.{AsyncHandler, HttpResponseBodyPart, HttpResponseHeaders, HttpResponseStatus}
+import org.asynchttpclient.{AsyncHandler, HttpResponseBodyPart, HttpResponseStatus}
+import io.netty.handler.codec.http.{HttpHeaders => HttpResponseHeaders}
 
 import scala.concurrent.Promise
 
@@ -14,7 +15,7 @@ class HttpHandler(config:CrawlConfig, url: WebUrl) extends AsyncHandler[Unit]{
   private[bubblewrap] var body = new ResponseBody
   var statusCode:Int = 200
   val httpResponse = Promise[HttpResponse]()
-  var headers: ResponseHeaders = new ResponseHeaders(new HttpResponseHeaders(new DefaultHttpHeaders))
+  var headers: ResponseHeaders = new ResponseHeaders(new DefaultHttpHeaders)
   val startTime = System.currentTimeMillis()
   val UNKNOWN_ERROR = 1006
   val TIMEOUT_ERROR = 9999

--- a/src/main/scala/bubblewrap/ResponseHeaders.scala
+++ b/src/main/scala/bubblewrap/ResponseHeaders.scala
@@ -1,6 +1,6 @@
 package bubblewrap
 
-import org.asynchttpclient.HttpResponseHeaders
+import io.netty.handler.codec.http.{HttpHeaders => HttpResponseHeaders}
 
 import scala.collection.JavaConversions._
 
@@ -8,12 +8,12 @@ import scala.collection.JavaConversions._
 class ResponseHeaders(httpResponseHeaders: HttpResponseHeaders) {
   val Charset = ".*charset\\s*=\\s*\\\"?([^;\\\"\\s]+)\\\"?\\s*".r
 
-  def exceedsSize(size:Long) = httpResponseHeaders.getHeaders.getAll("Content-Length").exists(_.toLong > size)
-  def redirectLocation = httpResponseHeaders.getHeaders.getAll("Location").headOption
+  def exceedsSize(size:Long) = httpResponseHeaders.getAll("Content-Length").exists(_.toLong > size)
+  def redirectLocation = httpResponseHeaders.getAll("Location").headOption
   def contentCharset = contentType.collect {
     case Charset(enc) => enc
   }
-  def contentType = httpResponseHeaders.getHeaders.getAll("Content-Type").headOption
-  def contentEncoding = httpResponseHeaders.getHeaders.getAll("Content-Encoding").headOption
-  def headers:Map[String,List[String]] = httpResponseHeaders.getHeaders.iterator().map(t => t.getKey -> httpResponseHeaders.getHeaders.getAll(t.getKey).toList).toMap
+  def contentType = httpResponseHeaders.getAll("Content-Type").headOption
+  def contentEncoding = httpResponseHeaders.getAll("Content-Encoding").headOption
+  def headers:Map[String,List[String]] = httpResponseHeaders.map(t => t.getKey -> httpResponseHeaders.getAll(t.getKey).toList).toMap
 }

--- a/src/test/scala/bubblewrap/HttpHandlerSpec.scala
+++ b/src/test/scala/bubblewrap/HttpHandlerSpec.scala
@@ -7,7 +7,8 @@ import bubblewrap.TestUtils._
 import io.netty.handler.codec.http.{DefaultHttpHeaders, HttpHeaders}
 import org.asynchttpclient.AsyncHandler.State
 import org.asynchttpclient.netty.NettyResponseStatus
-import org.asynchttpclient.{HttpResponseBodyPart, HttpResponseHeaders, HttpResponseStatus}
+import org.asynchttpclient.{HttpResponseBodyPart, HttpResponseStatus}
+import io.netty.handler.codec.http.{HttpHeaders => HttpResponseHeaders}
 import org.mockito.Mockito._
 import org.scalatest.FlatSpec
 import org.scalatest.Inside
@@ -26,7 +27,7 @@ class HttpHandlerSpec extends FlatSpec with Inside{
   def httpHeaders(headers:(String, String)*) = {
     val defaultHeaders = new DefaultHttpHeaders
     headers.foreach(h=>defaultHeaders.add(h._1,h._2))
-     new HttpResponseHeaders(defaultHeaders)
+    defaultHeaders
   }
 
   def bodyPart(value:Array[Byte]) = {

--- a/src/test/scala/bubblewrap/ResponseHeadersSpec.scala
+++ b/src/test/scala/bubblewrap/ResponseHeadersSpec.scala
@@ -1,13 +1,13 @@
 package bubblewrap
 
 import io.netty.handler.codec.http.DefaultHttpHeaders
-import org.asynchttpclient.HttpResponseHeaders
+import io.netty.handler.codec.http.{HttpHeaders => HttpResponseHeaders}
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers.{be, convertToAnyShouldWrapper}
 
 class ResponseHeadersSpec extends FlatSpec {
   "ResponseHeader" should "read content length header and say whether it exceeds size or not" in {
-    val headers: ResponseHeaders = new ResponseHeaders(new HttpResponseHeaders(new DefaultHttpHeaders().add("Content-Length", "10")))
+    val headers: ResponseHeaders = new ResponseHeaders(new DefaultHttpHeaders().add("Content-Length", "10"))
 
     headers.exceedsSize(10) should be(false)
     headers.exceedsSize(11) should be(false)
@@ -15,33 +15,33 @@ class ResponseHeadersSpec extends FlatSpec {
   }
 
   it should "read redirect location and give back" in {
-    val headers: ResponseHeaders = new ResponseHeaders(new HttpResponseHeaders(new DefaultHttpHeaders().add("Location", "/home")))
+    val headers: ResponseHeaders = new ResponseHeaders(new DefaultHttpHeaders().add("Location", "/home"))
 
     headers.redirectLocation should be(Some("/home"))
   }
 
   it should "give back nothing in case there are no Location header" in {
-    val headers: ResponseHeaders = new ResponseHeaders(new HttpResponseHeaders(new DefaultHttpHeaders()))
+    val headers: ResponseHeaders = new ResponseHeaders(new DefaultHttpHeaders())
 
     headers.redirectLocation should be(None)
   }
 
   it should "parse out content encoding from Content-Type header" in {
-    val headers: ResponseHeaders = new ResponseHeaders(new HttpResponseHeaders(new DefaultHttpHeaders().add("Content-Type", "text/html; charset=EUC-JP")))
+    val headers: ResponseHeaders = new ResponseHeaders(new DefaultHttpHeaders().add("Content-Type", "text/html; charset=EUC-JP"))
 
     headers.contentCharset should be(Some("EUC-JP"))
   }
 
   it should "parse out content encoding optionally enclosed in quotes" in {
-    val headers: ResponseHeaders = new ResponseHeaders(new HttpResponseHeaders(new DefaultHttpHeaders().add("Content-Type", "text/xml; charset=\"UTF-8\"")))
+    val headers: ResponseHeaders = new ResponseHeaders(new DefaultHttpHeaders().add("Content-Type", "text/xml; charset=\"UTF-8\""))
 
     headers.contentCharset should be(Some("UTF-8"))
   }
 
   it should "give out headers as map" in {
-    val headers: ResponseHeaders = new ResponseHeaders(new HttpResponseHeaders(new DefaultHttpHeaders()
+    val headers: ResponseHeaders = new ResponseHeaders(new DefaultHttpHeaders()
                                         .add("Content-Type", "text/xml; charset=\"UTF-8\"")
-                                        .add("X-Custom-Header", "Custom value")))
+                                        .add("X-Custom-Header", "Custom value"))
 
     headers.headers should be(Map(
       "Content-Type" -> List("text/xml; charset=\"UTF-8\""),


### PR DESCRIPTION
This provides a much-needed upgrade to the latest AHC version. This comes with a slew of fixes — especially https://github.com/AsyncHttpClient/async-http-client/commit/3e7596c52764b072e4843a6c2625b662d3002780 that lets us preserve hash fragments in URLs.

🙏🏻 Many thanks to @rbs392 for helping with this!