### PR TITLE
More thorough case matches for Gzip pages

### DIFF
--- a/src/main/scala/bubblewrap/PageParser.scala
+++ b/src/main/scala/bubblewrap/PageParser.scala
@@ -44,12 +44,8 @@ trait ContentType {
   )
 
   def isGzip(content: Content) = {
-    (content.contentEncoding, content.contentType) match {
-      case (Some(encoding), Some(cType)) => gzipVariants.contains(encoding) || gzipVariants.contains(cType)
-      case (Some(encoding), _) => gzipVariants.contains(encoding)
-      case (_, Some(cType)) => gzipVariants.contains(cType)
-      case (_, _) => false
-    }
+    val cType = Some(content.contentType.getOrElse("").split(";").head)
+    content.contentEncoding.exists(gzipVariants.contains) || cType.exists(gzipVariants.contains)
   }
 }
 

--- a/src/main/scala/bubblewrap/PageParser.scala
+++ b/src/main/scala/bubblewrap/PageParser.scala
@@ -44,8 +44,8 @@ trait ContentType {
   )
 
   def isGzip(content: Content) = {
-    val cType = Some(content.contentType.getOrElse("").split(";").head)
-    content.contentEncoding.exists(gzipVariants.contains) || cType.exists(gzipVariants.contains)
+    val cType: Option[String] = content.contentType.flatMap(_.split(";").headOption)
+    cType.exists(gzipVariants.contains) || content.contentEncoding.exists(gzipVariants.contains)
   }
 }
 

--- a/src/main/scala/bubblewrap/PageParser.scala
+++ b/src/main/scala/bubblewrap/PageParser.scala
@@ -45,8 +45,9 @@ trait ContentType {
 
   def isGzip(content: Content) = {
     (content.contentEncoding, content.contentType) match {
-      case (Some(encoding), _) => gzipVariants.exists(gz => gz.equals(encoding))
-      case (_, Some(cType)) => gzipVariants.exists(gz => gz.equals(cType))
+      case (Some(encoding), Some(cType)) => gzipVariants.contains(encoding) || gzipVariants.contains(cType)
+      case (Some(encoding), _) => gzipVariants.contains(encoding)
+      case (_, Some(cType)) => gzipVariants.contains(cType)
       case (_, _) => false
     }
   }

--- a/src/test/scala/bubblewrap/ContentSpec.scala
+++ b/src/test/scala/bubblewrap/ContentSpec.scala
@@ -39,7 +39,7 @@ class ContentSpec  extends FlatSpec{
 
   it should "read Gzipped content (with ISO-8859-1 encoding) to string" in {
     val encoding = "ISO-8859-1"
-    val gzipped = readAsBytes("/fixtures/2-ungzipped-iso8859-1.html")
+    val gzipped = readAsBytes("/fixtures/2-gzipped-iso8859-1.html")
     val ungzipped = readAsBytes("/fixtures/2-ungzipped-iso8859-1.html")
     val content = Content(WebUrl("http://www.example.com/dummy"), gzipped, contentType = Some("application/gzip; charset=iso-8859-1"), contentCharset = Some(encoding), contentEncoding = None)
 

--- a/src/test/scala/bubblewrap/ContentSpec.scala
+++ b/src/test/scala/bubblewrap/ContentSpec.scala
@@ -19,11 +19,20 @@ class ContentSpec  extends FlatSpec{
     content.asString should be(koreanString)
   }
 
-  it should "read Gzipped content (with UTF-8 encoding) to string" in {
+  it should "read Gzipped content (with UTF-8 encoding & text/html content type) to string" in {
     val encoding = "UTF-8"
     val gzipped = readAsBytes("/fixtures/1-gzipped.html")
     val ungzipped = readAsBytes("/fixtures/1-ungzipped.html")
-    val content = Content(WebUrl("http://www.example.com/dummy"), gzipped, Some("text/html; charset=utf-8"), Some(encoding), Some("gzip"))
+    val content = Content(WebUrl("http://www.example.com/dummy"), gzipped, contentType = Some("text/html; charset=utf-8"), contentCharset = Some(encoding), contentEncoding = Some("gzip"))
+
+    content.asString should be (new String(ungzipped, encoding))
+  }
+
+  it should "read Gzipped content (with UTF-8 encoding & gzip content type) to string" in {
+    val encoding = "UTF-8"
+    val gzipped = readAsBytes("/fixtures/1-gzipped.html")
+    val ungzipped = readAsBytes("/fixtures/1-ungzipped.html")
+    val content = Content(WebUrl("http://www.example.com/dummy"), gzipped, contentType = Some("gzip"), contentCharset = Some(encoding), contentEncoding = Some("text/html; charset=UTF-8"))
 
     content.asString should be (new String(ungzipped, encoding))
   }
@@ -32,7 +41,7 @@ class ContentSpec  extends FlatSpec{
     val encoding = "ISO-8859-1"
     val gzipped = readAsBytes("/fixtures/2-ungzipped-iso8859-1.html")
     val ungzipped = readAsBytes("/fixtures/2-ungzipped-iso8859-1.html")
-    val content = Content(WebUrl("http://www.example.com/dummy"), gzipped, Some("application/gzip; charset=iso-8859-1"), Some(encoding), None)
+    val content = Content(WebUrl("http://www.example.com/dummy"), gzipped, contentType = Some("application/gzip; charset=iso-8859-1"), contentCharset = Some(encoding), contentEncoding = None)
 
     content.asString should be (new String(ungzipped, encoding))
   }


### PR DESCRIPTION
The case match that landed in #11 wasn't exhaustive enough for combinations like `Content-Type: gzip` and `Content-Encoding: <whatever>`. This PR fixes that.

🙏🏻 Thanks @anant-indix for helping internally reproduce this!