### PR TITLE
Fix memory leaks by freeing up futures resources

### DIFF
--- a/src/main/scala/bubblewrap/HttpClient.scala
+++ b/src/main/scala/bubblewrap/HttpClient.scala
@@ -54,7 +54,7 @@ class HttpClient(clientSettings: ClientSettings = ClientSettings()) {
       .addHeader(USER_AGENT, config.userAgent)
       .setCookies(HttpClient.cookies(config, url.toString).asJava)
     config.customHeaders.headers.foreach(header => request.addHeader(header._1.trim(), header._2))
-    request.execute(handler)
+    request.execute(handler).done()
     handler.httpResponse.future
   }
 


### PR DESCRIPTION
This is how i tested it using `sbt console`:

```scala
import bubblewrap._
import scala.concurrent._
import scala.concurrent.duration._


val cl = new HttpClient()
val cc = CrawlConfig(None, "test", 1000000000,0)
val url = WebUrl("https://www.wikipedia.org")
(0 to 100).foreach(_ => cl.get(url,cc))
Await.result((0 to 100).map(_ => cl.get(url,cc)).head, 10 seconds)
```

Try opening a `sbt console` session and paste the above code block, first without this fix and figure out the number of live `NettyResponseFuture` objects using `jmap -histo:live <pid of sbt process> | grep -i NettyResponseFuture`. Repeat the same experiment with this fix. Ideally, you would see lots of NettyResponseFuture object before this fix, whereas no objects after this fix. 