### PR TITLE
Added a download page test case

### DIFF
--- a/src/test/scala/bubblewrap/HttpClientSpec.scala
+++ b/src/test/scala/bubblewrap/HttpClientSpec.scala
@@ -1,0 +1,15 @@
+package bubblewrap
+
+import org.scalatest.AsyncFlatSpec
+
+class HttpClientSpec extends AsyncFlatSpec {
+  it should "download a page" in {
+    val client = new HttpClient()
+    val request = client.get(WebUrl("http://www.example.com"), CrawlConfig(None, "bubblewrap", 1000000, 5, Cookies.None))
+
+    request map {
+      case HttpResponse(_, SuccessResponse(content), _, _) => assert(content.length > 0)
+      case _ => assert(false)
+    }
+  }
+}


### PR DESCRIPTION
Checks weather the client has actually downloaded some content

It fails after : https://github.com/indix/bubblewrap/commit/4e5ae78cffc241d8c7ae1c75b75af20faa2d3811
Without the above change it succeeds