### PR TITLE
lazy val asString to allow decompression outside IO thread pool

### DIFF
--- a/src/main/scala/bubblewrap/HttpHandler.scala
+++ b/src/main/scala/bubblewrap/HttpHandler.scala
@@ -33,7 +33,6 @@ class HttpHandler(config:CrawlConfig, url: WebUrl) extends AsyncHandler[Unit]{
 
   override def onCompleted(): Unit = {
     val content = Content(url, body.content, headers)
-    if (content.contentLength <= config.minSize && statusCode == 200) statusCode = CAPTCHA_CONTENT
     //emptying the body, so that the content doesn't get referenced in the HashedWheelTimerBucket
     body = null
     httpResponse.success(HttpResponse(statusCode, SuccessResponse(content), headers, responseTime))

--- a/src/main/scala/bubblewrap/PageParser.scala
+++ b/src/main/scala/bubblewrap/PageParser.scala
@@ -11,7 +11,7 @@ import scala.collection.JavaConversions._
 import scala.util.Try
 
 case class Content(url: WebUrl, content: Array[Byte], contentType: Option[String] = None, contentCharset: Option[String] = None, contentEncoding: Option[String] = None) extends ContentType {
-  val asString: String = new String(asBytes, contentCharset.getOrElse("UTF-8").toUpperCase)
+  lazy val asString: String = new String(asBytes, contentCharset.getOrElse("UTF-8").toUpperCase)
 
   def asBytes = if (isGzip(this)) {
     Try(decompress(content)).getOrElse(content)

--- a/src/test/scala/bubblewrap/HttpHandlerSpec.scala
+++ b/src/test/scala/bubblewrap/HttpHandlerSpec.scala
@@ -142,20 +142,6 @@ class HttpHandlerSpec extends FlatSpec with Inside{
     get(response).status should be(9998)
   }
 
-  it should "use captcha error code when content length is smaller than captcha content length for 200 status" in {
-    val handler = new HttpHandler(config, url)
-    val response = handler.httpResponse.future
-    handler.onStatusReceived(httpStatus(200))
-
-    handler.onHeadersReceived(httpHeaders()) should be(State.CONTINUE)
-    handler.onBodyPartReceived(bodyPart("small".getBytes)) should be(State.CONTINUE)
-
-    handler.onCompleted()
-
-    response.isCompleted should be(true)
-    get(response).status should be(9997)
-  }
-
   it should "not use captcha error code when content length is smaller than captcha content length for non 200 status" in {
     val handler = new HttpHandler(config, url)
     val response = handler.httpResponse.future


### PR DESCRIPTION
Making `asString` in `Content` lazy val to not have decompression happening in the IO thread pool.