### PR TITLE
GC friendly HTTPHandler

### DIFF
--- a/src/main/scala/bubblewrap/HttpClient.scala
+++ b/src/main/scala/bubblewrap/HttpClient.scala
@@ -1,7 +1,7 @@
 package bubblewrap
 
 import java.net.URL
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{Executors, TimeUnit}
 
 import io.netty.handler.codec.http.HttpHeaders.Names._
 import io.netty.handler.codec.http.HttpHeaders.Values._
@@ -9,19 +9,16 @@ import io.netty.handler.codec.http.cookie.ClientCookieDecoder
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory
 import io.netty.handler.ssl.{SslContextBuilder, SslProvider}
 import io.netty.util.HashedWheelTimer
-import org.asynchttpclient.netty.NettyResponseFuture
-import org.asynchttpclient.netty.channel.DefaultChannelPool
 import org.asynchttpclient.proxy.ProxyServer
 import org.asynchttpclient.{DefaultAsyncHttpClient, DefaultAsyncHttpClientConfig, Realm}
 
 import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.Try
+import scala.concurrent.{ExecutionContext, Promise}
 
 class HttpClient(clientSettings: ClientSettings = ClientSettings()) {
   val lenientSSLContext = SslContextBuilder.forClient().sslProvider(SslProvider.JDK).trustManager(InsecureTrustManagerFactory.INSTANCE).build()
 
-  val timer = new HashedWheelTimer(100, TimeUnit.MILLISECONDS, 3072)
+  val timer = new HashedWheelTimer(100, TimeUnit.MILLISECONDS, 100)
   val client = new DefaultAsyncHttpClient(new DefaultAsyncHttpClientConfig.Builder()
                                           .setConnectTimeout(clientSettings.connectionTimeout)
                                           .setRequestTimeout(clientSettings.requestTimeout)
@@ -30,12 +27,13 @@ class HttpClient(clientSettings: ClientSettings = ClientSettings()) {
                                           .setUseInsecureTrustManager(true)
                                           .setMaxRequestRetry(clientSettings.retries)
                                           .setFollowRedirect(false)
-                                          .setKeepAlive(clientSettings.keepAlive)
-                                          .setNettyTimer(timer).build())
+                                          .setKeepAlive(clientSettings.keepAlive).setNettyTimer(timer)
+                                          .build())
 
 
   def get(url: WebUrl, config: CrawlConfig) = {
-    val handler = new HttpHandler(config, url)
+    val httpResponse = Promise[HttpResponse]()
+    val handler = new HttpHandler(config, url, httpResponse)
     val request = client.prepareGet(url.toString)
     config.proxy.foreach {
       case PlainProxy(host, port) => request.setProxyServer(new ProxyServer.Builder(host, port).build())
@@ -55,7 +53,9 @@ class HttpClient(clientSettings: ClientSettings = ClientSettings()) {
       .setCookies(HttpClient.cookies(config, url.toString).asJava)
     config.customHeaders.headers.foreach(header => request.addHeader(header._1.trim(), header._2))
     request.execute(handler)
-    handler.httpResponse.future
+    val responseFuture = httpResponse.future
+    responseFuture.onComplete(_ => handler.httpResponse = null)(HttpClient.executionContext)
+    responseFuture
   }
 
   def shutDown() = {
@@ -64,6 +64,9 @@ class HttpClient(clientSettings: ClientSettings = ClientSettings()) {
 }
 
 object HttpClient {
+  private val executors          = Executors.newFixedThreadPool(1)
+  val executionContext  = ExecutionContext.fromExecutorService(executors)
+
   val oneYear = 360l * 24 * 60 * 60 * 1000
 
   def cookies(config: CrawlConfig, url: String) = {

--- a/src/main/scala/bubblewrap/HttpClient.scala
+++ b/src/main/scala/bubblewrap/HttpClient.scala
@@ -54,6 +54,8 @@ class HttpClient(clientSettings: ClientSettings = ClientSettings()) {
     config.customHeaders.headers.foreach(header => request.addHeader(header._1.trim(), header._2))
     request.execute(handler)
     val responseFuture = httpResponse.future
+    // HashedWheelTimer maintains NettyResponseFutures till timeout task reaps them.
+    // AsyncHandlers are designed in a way to just store code, but storing HTTPResponse inside handler will bloat up the heap.
     responseFuture.onComplete(_ => handler.httpResponse = null)
     responseFuture
   }

--- a/src/main/scala/bubblewrap/HttpHandler.scala
+++ b/src/main/scala/bubblewrap/HttpHandler.scala
@@ -4,17 +4,15 @@ package bubblewrap
 import java.io.IOException
 import java.util.concurrent.TimeoutException
 
-import io.netty.handler.codec.http.DefaultHttpHeaders
+import io.netty.handler.codec.http.{DefaultHttpHeaders, HttpHeaders => HttpResponseHeaders}
 import org.asynchttpclient.AsyncHandler.State
 import org.asynchttpclient.{AsyncHandler, HttpResponseBodyPart, HttpResponseStatus}
-import io.netty.handler.codec.http.{HttpHeaders => HttpResponseHeaders}
 
 import scala.concurrent.Promise
 
-class HttpHandler(config:CrawlConfig, url: WebUrl) extends AsyncHandler[Unit]{
+class HttpHandler(config:CrawlConfig, url: WebUrl, var httpResponse: Promise[HttpResponse]) extends AsyncHandler[Unit]{
   private[bubblewrap] var body = new ResponseBody
   var statusCode:Int = 200
-  val httpResponse = Promise[HttpResponse]()
   var headers: ResponseHeaders = new ResponseHeaders(new DefaultHttpHeaders)
   val startTime = System.currentTimeMillis()
   val UNKNOWN_ERROR = 1006

--- a/src/main/scala/bubblewrap/PageParser.scala
+++ b/src/main/scala/bubblewrap/PageParser.scala
@@ -28,7 +28,7 @@ case class Content(url: WebUrl, content: Array[Byte], contentType: Option[String
 
   private def decompress(contentBytes: Array[Byte]): Array[Byte] = {
     val inputStream = new ByteArrayInputStream(contentBytes)
-    val gzipInStream = new GZIPInputStream(inputStream)
+    val gzipInStream = new GZIPInputStream(inputStream, 512)
     val out = new ByteArrayOutputStream()
     try {
       IOUtils.copy(gzipInStream, out)

--- a/src/test/scala/bubblewrap/HttpClientSpec.scala
+++ b/src/test/scala/bubblewrap/HttpClientSpec.scala
@@ -1,0 +1,15 @@
+package bubblewrap
+
+import org.scalatest.AsyncFlatSpec
+
+class HttpClientSpec extends AsyncFlatSpec {
+  it should "download a page" in {
+    val client = new HttpClient()
+    val request = client.get(WebUrl("http://www.example.com"), CrawlConfig(None, "bubblewrap", 1000000, 5, Cookies.None))
+
+    request map {
+      case HttpResponse(_, SuccessResponse(content), _, _) => assert(content.length > 0)
+      case _ => assert(false)
+    }
+  }
+}

--- a/src/test/scala/bubblewrap/HttpHandlerSpec.scala
+++ b/src/test/scala/bubblewrap/HttpHandlerSpec.scala
@@ -14,6 +14,8 @@ import org.scalatest.FlatSpec
 import org.scalatest.Inside
 import org.scalatest.Matchers.{be, convertToAnyShouldWrapper}
 
+import scala.concurrent.Promise
+
 class HttpHandlerSpec extends FlatSpec with Inside{
   val config: CrawlConfig = CrawlConfig(None, "bubblewrap", 1000, 5, Cookies.None)
   val url = WebUrl("http://www.example.com/1")
@@ -37,7 +39,7 @@ class HttpHandlerSpec extends FlatSpec with Inside{
   }
 
   "HttpHandler" should "add parts to the body and fulfil body once complete" in {
-    val handler = new HttpHandler(config, url)
+    val handler = new HttpHandler(config, url, Promise[HttpResponse]())
     val response = handler.httpResponse.future
     handler.onStatusReceived(httpStatus(200))
 
@@ -55,7 +57,7 @@ class HttpHandlerSpec extends FlatSpec with Inside{
   }
 
   it should "abort in case the content-length header has larger size than in crawl config" in {
-    val handler = new HttpHandler(config, url)
+    val handler = new HttpHandler(config, url, Promise[HttpResponse]())
     val response = handler.httpResponse.future
     handler.onStatusReceived(httpStatus(200))
 
@@ -67,7 +69,7 @@ class HttpHandlerSpec extends FlatSpec with Inside{
   }
 
   it should "continue if the content-length is well within max size" in {
-    val handler = new HttpHandler(config, url)
+    val handler = new HttpHandler(config, url, Promise[HttpResponse]())
     val response = handler.httpResponse.future
     handler.onStatusReceived(httpStatus(200))
 
@@ -76,7 +78,7 @@ class HttpHandlerSpec extends FlatSpec with Inside{
   }
 
   it should "abort if the body content exceeds the max size" in {
-    val handler = new HttpHandler(config, url)
+    val handler = new HttpHandler(config, url, Promise[HttpResponse]())
     val response = handler.httpResponse.future
     handler.onStatusReceived(httpStatus(200))
 
@@ -90,7 +92,7 @@ class HttpHandlerSpec extends FlatSpec with Inside{
   }
 
   it should "have location in the response in case of redirects" in {
-    val handler = new HttpHandler(config, url)
+    val handler = new HttpHandler(config, url, Promise[HttpResponse]())
     val response = handler.httpResponse.future
     handler.onStatusReceived(httpStatus(302))
 
@@ -102,7 +104,7 @@ class HttpHandlerSpec extends FlatSpec with Inside{
 
   it should "use the content-type header to parse the body part" in {
     val koreanString = "동서게임 MS정품유선컨트롤러/PCGTA5호환 - 11번가"
-    val handler = new HttpHandler(config, url)
+    val handler = new HttpHandler(config, url, Promise[HttpResponse]())
     val response = handler.httpResponse.future
     handler.onStatusReceived(httpStatus(200))
 
@@ -117,7 +119,7 @@ class HttpHandlerSpec extends FlatSpec with Inside{
   }
 
   it should "use timeout error code when reporting connection and read timeouts" in {
-    val handler = new HttpHandler(config, url)
+    val handler = new HttpHandler(config, url, Promise[HttpResponse]())
     val response = handler.httpResponse.future
 
     handler.onThrowable(new TimeoutException("read timeout"))
@@ -126,7 +128,7 @@ class HttpHandlerSpec extends FlatSpec with Inside{
 
 
   it should "use unknown error code when reporting exceptions which arent timeouts" in {
-    val handler = new HttpHandler(config, url)
+    val handler = new HttpHandler(config, url, Promise[HttpResponse]())
     val response = handler.httpResponse.future
 
     handler.onThrowable(new RuntimeException("I dont know what went wrong, really")) 
@@ -135,7 +137,7 @@ class HttpHandlerSpec extends FlatSpec with Inside{
 
 
   it should "use remotely closed error code when reporting ioexception with remotely closed as message" in {
-    val handler = new HttpHandler(config, url)
+    val handler = new HttpHandler(config, url, Promise[HttpResponse]())
     val response = handler.httpResponse.future
 
     handler.onThrowable(new IOException("Remotely closed"))
@@ -143,7 +145,7 @@ class HttpHandlerSpec extends FlatSpec with Inside{
   }
 
   it should "not use captcha error code when content length is smaller than captcha content length for non 200 status" in {
-    val handler = new HttpHandler(config, url)
+    val handler = new HttpHandler(config, url, Promise[HttpResponse]())
     val response = handler.httpResponse.future
     handler.onStatusReceived(httpStatus(302))
 


### PR DESCRIPTION
At the moment, [httpResponse](https://github.com/indix/bubblewrap/blob/master/src/main/scala/bubblewrap/HttpHandler.scala#L17) is an instance val as part of the HTTPHandler. AsyncHTTPClient ties up this handler with NettyResponseFuture, which gets queued into the HashedWheelTimer. This means, the entire response will be available until keepAlive and the reapers triggers and clears up these objects. In order to free up the response data real quick, we need a hack by de-referencing it.  Looks hard for our eyes, but makes real impact.

The other change is with respect to having a small wheel so that timeoutTasks are checked more frequently.